### PR TITLE
Fixes #1 Test fail on django 1.8

### DIFF
--- a/PollsDjango/app/tests.py
+++ b/PollsDjango/app/tests.py
@@ -15,6 +15,7 @@ class ViewTest(TestCase):
         # Django 1.7 requires an explicit setup() when running tests in PTVS
         @classmethod
         def setUpClass(cls):
+            super(ViewTest, cls).setUpClass()
             django.setup()
 
     def test_home(self):


### PR DESCRIPTION
Super call to setUpClass is needed to make tests pass.  This change was
already made to the starter django template in microsoft/ptvs
